### PR TITLE
Fixed Layout overlapping in Material Theme changer layout.

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="syntaxspin_phrase">A Material You Lover Android/Web Developer</string> 
     <string name="yamenher_phrase">A Kool Utilities maker</string>
     <string name="trindadedev_phrase">I use Jetpack Compose, btw</string>
-    <string name="monet_title">Use Dynamic Colors in Sparkles</string>
-    <string name="monet_desc">Use your device color pallet instead Sparkles Green</string>
+    <string name="monet_title">Apply Dynamic Colors</string>
+    <string name="monet_desc">Turn Me into Material You.</string>
     <string name="need_restart">Need Restart</string>
 </resources>


### PR DESCRIPTION
Updated Strings: Material You preference title and description to fix the overlapping layout of Text and MaterialSwitch.